### PR TITLE
Adding UA Identifiers to Gimbal Device Attributes

### DIFF
--- a/UAGimbalAdapter.m
+++ b/UAGimbalAdapter.m
@@ -2,12 +2,13 @@
 
 #import "UAGimbalAdapter.h"
 
-@import <Gimbal/Gimbal.h>
+#import <Gimbal/Gimbal.h>
 @import AirshipKit;
 
 @interface UAGimbalAdapter() <GMBLPlaceManagerDelegate>
-@property (nonatomic, assign, getter=isStarted) BOOL started;
 @property (nonatomic, strong) GMBLPlaceManager *placeManager;
+@property (nonatomic) GMBLDeviceAttributesManager * deviceAttributesManager;
+@property (nonatomic, assign, getter=isStarted) BOOL started;
 @end
 
 NSString *const GimbalSource = @"Gimbal";
@@ -19,18 +20,33 @@ NSString *const GimbalAlertViewKey = @"gmbl_hide_bt_power_alert_view";
 
 static id _sharedObject = nil;
 
-
 + (void)load {
-    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-    [center addObserver:[UAGimbalAdapter class]
-               selector:@selector(handleAppDidFinishLaunching)
-                   name:UIApplicationDidFinishLaunchingNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:[UAGimbalAdapter class]
+                                             selector:@selector(handleAppDidFinishLaunching)
+                                                 name:UIApplicationDidFinishLaunchingNotification
+                                               object:nil];
+}
+
++ (void)handleAppDidFinishLaunching {
+    [[NSNotificationCenter defaultCenter] removeObserver:[UAGimbalAdapter class]
+                                                    name:UIApplicationDidFinishLaunchingNotification
+                                                  object:nil];
+    [[UAGimbalAdapter shared] restore];
+}
+
++ (instancetype)shared {
+    static dispatch_once_t onceToken = 0;
+    dispatch_once(&onceToken, ^{
+        _sharedObject = [[self alloc] init];
+    });
+    return _sharedObject;
 }
 
 - (instancetype)init {
     self = [super init];
     if (self) {
         self.placeManager = [[GMBLPlaceManager alloc] init];
+        self.deviceAttributesManager = [GMBLDeviceAttributesManager new];
 
         // Hide the power alert by default
         if (![[NSUserDefaults standardUserDefaults] valueForKey:GimbalAlertViewKey]) {
@@ -45,24 +61,10 @@ static id _sharedObject = nil;
     self.placeManager.delegate = nil;
 }
 
-
-+ (instancetype)shared {
-    static dispatch_once_t onceToken = 0;
-    dispatch_once(&onceToken, ^{
-        _sharedObject = [[self alloc] init];
-    });
-
-    return _sharedObject;
-}
-
-+ (void)handleAppDidFinishLaunching {
-    [[NSNotificationCenter defaultCenter] removeObserver:[UAGimbalAdapter class]
-                                                    name:UIApplicationDidFinishLaunchingNotification
-                                                  object:nil];
-
-    if ([GMBLPlaceManager isMonitoring]) {
-        [[UAGimbalAdapter shared] startWithGimbalAPIKey:nil];
-    }
+- (void)restore {
+    self.started = [Gimbal isStarted];
+    self.placeManager.delegate = self;
+    [self setDeviceAttributes];
 }
 
 - (BOOL)isBluetoothPoweredOffAlertEnabled {
@@ -75,42 +77,42 @@ static id _sharedObject = nil;
 }
 
 - (void)startWithGimbalAPIKey:(NSString *)gimbalAPIKey {
-    if (self.isStarted) {
-        return;
-    }
-
-    if (gimbalAPIKey.length) {
-        [Gimbal setAPIKey:gimbalAPIKey options:nil];
-    } else if (![GMBLPlaceManager isMonitoring]) {
-        NSLog(@"GMBLPlaceManager is not previously started and API key is not provided. Unable to start Gimbal Adapter.");
-        return;
-    }
-
-    self.placeManager.delegate = self;
-    [GMBLPlaceManager startMonitoring];
+    [Gimbal setAPIKey:gimbalAPIKey options:nil];
+    [Gimbal start];
     self.started = YES;
+    self.placeManager.delegate = self;
+    [self setDeviceAttributes];
     UA_LDEBUG(@"Started Gimbal Adapter. Gimbal application instance identifier: %@", [Gimbal applicationInstanceIdentifier]);
 }
 
-- (void)stop {
-    if (!self.isStarted) {
-        return;
+- (void)setDeviceAttributes {
+    NSMutableDictionary *deviceAttributes = [NSMutableDictionary new];
+    if ([[self.deviceAttributesManager getDeviceAttributes] count] > 0) {
+        [deviceAttributes addEntriesFromDictionary:[self.deviceAttributesManager getDeviceAttributes]];
     }
+    if ([UAirship namedUser].identifier) {
+        [deviceAttributes setObject:[UAirship namedUser].identifier forKey:@"ua.nameduser.id"];
+    }
+    if ([UAirship push].channelID) {
+        [deviceAttributes setObject:[UAirship push].channelID forKey:@"ua.channel.id"];
+    }
+    if ([deviceAttributes count] > 0) {
+        [self.deviceAttributesManager setDeviceAttributes:deviceAttributes];
+        UA_LDEBUG(@"Set Gimbal Device Attributes: %@", [deviceAttributes description]);
+    }
+}
 
-    [GMBLPlaceManager stopMonitoring];
-    self.placeManager.delegate = nil;
+- (void)stop {
+    [Gimbal stop];
     self.started = NO;
-
+    self.placeManager.delegate = nil;
     UA_LDEBUG(@"Stopped Gimbal Adapter.");
 }
 
-
-#pragma mark -
-#pragma mark Gimbal places callbacks
+#pragma mark Gimbal place callbacks
 
 - (void)placeManager:(GMBLPlaceManager *)manager didBeginVisit:(GMBLVisit *)visit {
     UA_LDEBUG(@"Entered a Gimbal Place: %@ on the following date: %@", visit.place.name, visit.arrivalDate);
-
     UARegionEvent *regionEvent = [UARegionEvent regionEventWithRegionID:visit.place.identifier
                                                                  source:GimbalSource
                                                           boundaryEvent:UABoundaryEventEnter];
@@ -120,10 +122,10 @@ static id _sharedObject = nil;
 
 - (void)placeManager:(GMBLPlaceManager *)manager didEndVisit:(GMBLVisit *)visit {
     UA_LDEBUG(@"Exited a Gimbal Place: %@ Entrance date:%@ Exit Date:%@", visit.place.name, visit.arrivalDate, visit.departureDate);
-
     UARegionEvent *regionEvent = [UARegionEvent regionEventWithRegionID:visit.place.identifier
                                                                  source:GimbalSource
                                                           boundaryEvent:UABoundaryEventExit];
+    [[UAirship shared].analytics addEvent:regionEvent];
 }
 
 

--- a/UAGimbalAdapter.m
+++ b/UAGimbalAdapter.m
@@ -96,7 +96,7 @@ static id _sharedObject = nil;
     if ([UAirship push].channelID) {
         [deviceAttributes setObject:[UAirship push].channelID forKey:@"ua.channel.id"];
     }
-    if ([deviceAttributes count] > 0) {
+    if (deviceAttributes.count > 0) {
         [self.deviceAttributesManager setDeviceAttributes:deviceAttributes];
         UA_LDEBUG(@"Set Gimbal Device Attributes: %@", [deviceAttributes description]);
     }


### PR DESCRIPTION
Gimbal is adding the Urban Airship channel ID and named user ID to the
Gimbal Device Attributes.

The reason for this is to allow customers to link their UA Push
Messaging data to Gimbal Place Events in Gimbal Manager based on these
identifiers being related to the Gimbal Application Instance ID.

We also made some implementation changes to attempt to make the code
more readable and efficient. We did not make any public interface
changes.