### PR TITLE
MOBILE-2123 Update for Airship 14.3.0, Gimbal 2.85 support

### DIFF
--- a/AirshipGimbalAdapter.podspec
+++ b/AirshipGimbalAdapter.podspec
@@ -1,6 +1,6 @@
 
 Pod::Spec.new do |s|
-  s.version                 = "2.0.0"
+  s.version                 = "2.1.0"
   s.name                    = "AirshipGimbalAdapter"
   s.summary                 = "An adapter for integrating Gimbal place events with Airship."
   s.documentation_url       = "https://github.com/urbanairship/ios-gimbal-adapter"
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.swift_version           = "5.0"
   s.source_files            = "Pod/Classes/*"
   s.requires_arc            = true
-  s.dependency                "Gimbal", "~> 2.0"
-  s.dependency                "Airship", "~> 14.1.2"
+  s.dependency                "Gimbal", "~> 2.85"
+  s.dependency                "Airship", "~> 14.3.0"
   s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
   s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,14 @@
 ChangeLog
 =========
 
+Version 2.1.0 March 15, 2021
+============================
+- Updated for Airship SDK 14.3.0
+- Requires Gimbal SDK 2.85 and above
+
 Version 2.0.0 October 14, 2020
 ==============================
-- Updated for Airshp SDK 14.1.2
+- Updated for Airship SDK 14.1.2
 - Cocoapods support
 - Renamed `GimbalAdapter` to `AirshipGimbalAdapter
 - Removed `UAGimbalAdapter` class.


### PR DESCRIPTION
From 2.85 Gimbal has changed the Swift names of classes and protocols to drop the GMBL prefix, and added `NS_ASSUME_NONNULL` annotations to their headers. This required some changes to our adapter to make it compile. Since it would be a breaking change otherwise I opted to keep the API key argument to the `start` method optional, with a guard let to make sure we handle the nil case.

I tested this on a fresh Cocoapods app and verified that it compiles and runs without errors on a device, using one of the API keys on our gimbal account in the dashboard.