### PR TITLE
Release 3.0.0

### DIFF
--- a/AirshipGimbalAdapter.podspec
+++ b/AirshipGimbalAdapter.podspec
@@ -1,6 +1,6 @@
 
 Pod::Spec.new do |s|
-  s.version                 = "2.1.0"
+  s.version                 = "3.0.0"
   s.name                    = "AirshipGimbalAdapter"
   s.summary                 = "An adapter for integrating Gimbal place events with Airship."
   s.documentation_url       = "https://github.com/urbanairship/ios-gimbal-adapter"
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.swift_version           = "5.0"
   s.source_files            = "Pod/Classes/*"
   s.requires_arc            = true
-  s.dependency                "Gimbal", "~> 2.85"
-  s.dependency                "Airship", "~> 14.3.0"
+  s.dependency                "Gimbal", "~> 2.87"
+  s.dependency                "Airship", "~> 14.8"
   s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
   s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 ChangeLog
 =========
 
+Version 3.0.0 November 10, 2021
+===============================
+- Updated to Airship SDK 14.8
+- Updated to Gimbal SDK 2.87
+- Requires Xcode 13+
+
 Version 2.1.0 March 15, 2021
 ============================
 - Updated for Airship SDK 14.3.0

--- a/Pod/Classes/AirshipGimbalAdapter.swift
+++ b/Pod/Classes/AirshipGimbalAdapter.swift
@@ -58,7 +58,7 @@ import Gimbal
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(AirshipGimbalAdapter.updateDeviceAttributes),
-                                               name: NSNotification.Name(UAChannelCreatedEvent),
+                                               name: NSNotification.Name.UAChannelCreatedEvent,
                                                object: nil)
     }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Airship Gimbal Adapter is a drop-in class that allows users to integrate Gim
 
 The Airship Gimbal Adapter is available through CocoaPods. To install it, simply add the following line to your Podfile:
 
-`pod "Airshp-Gimbal-Adapter"`
+`pod "AirshipGimbalAdapter"`
 
 ## Usage
 


### PR DESCRIPTION
Updates to SDK 14.8 and Gimbal 2.87. I was having issues with Gimbal 2.88 and Swift 5.5, but 2.87 works fine. We are using the optimistic version operator so people can specify any version newer than 2.87. Ill try to get support from Gimbal to resolve this issue.