### PR TITLE
Fix adapter in simulator

### DIFF
--- a/AirshipGimbalAdapter.podspec
+++ b/AirshipGimbalAdapter.podspec
@@ -14,6 +14,4 @@ Pod::Spec.new do |s|
   s.requires_arc            = true
   s.dependency                "Gimbal", "~> 2.85"
   s.dependency                "Airship", "~> 14.8"
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
GImbal does not seem to be available in the simulator so it prevents us from publishing. Adds checks for simulator before calling through to Gimbal. This makes it so the adapter still is callable in a simulator but it just no-ops