### PR TITLE
[GHI-9] remove optimistic operator for Gimbal SDK version

### DIFF
--- a/AirshipGimbalAdapter.podspec
+++ b/AirshipGimbalAdapter.podspec
@@ -1,6 +1,6 @@
 
 Pod::Spec.new do |s|
-  s.version                 = "4.1.0"
+  s.version                 = "4.1.1"
   s.name                    = "AirshipGimbalAdapter"
   s.summary                 = "An adapter for integrating Gimbal place events with Airship."
   s.documentation_url       = "https://github.com/urbanairship/ios-gimbal-adapter"
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.swift_version           = "5.0"
   s.source_files            = "Pod/Classes/*"
   s.requires_arc            = true
-  s.dependency                "Gimbal", "~> 2.85"
-  s.dependency                "Airship", "~> 16.7"
+  s.dependency                "Gimbal", "2.85"
+  s.dependency                "Airship", "16.7"
   s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
   s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## Version 4.1.1 July 5, 2022
+- Use Gimbal SDK 2.85
+
 ## Version 4.1.0 June 7, 2022
 - Updated to Airship SDK 16.7.0
 


### PR DESCRIPTION
We want to be sure the version of Gimbal is one we validated before so we remove the optimistic operator for the dependency.